### PR TITLE
Added vendor namespace to psr4 autoload to prevent clashes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "autoload": {
         "psr-4": {
-            "": "src/"
+            "Atrapalo\\": "src/Atrapalo"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
The current psr4 configuration can clash with other libraries that also define an empty `""` namespace. It is a best practice to register the psr4 autoloader under your own vendor namespace.
