### PR TITLE
Update elasticsearch client to version 5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "keywords": ["log", "logging", "logger", "monolog", "psr3", "psr-3", "elastic", "elasticsearch"],
     "require": {
-        "elasticsearch/elasticsearch": "^2.0"
+        "elasticsearch/elasticsearch": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",


### PR DESCRIPTION
I need the elasticsearch php client in version 5.
Tested local with elasticsearch server 5 and in production environment with elasticsearch version 2.3 (AWS).