### PR TITLE
dependency version requirement for Elasticsearch library was too limi…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "keywords": ["log", "logging", "logger", "monolog", "psr3", "psr-3", "elastic", "elasticsearch"],
     "require": {
-        "elasticsearch/elasticsearch": "^2.0"
+        "elasticsearch/elasticsearch": ">=2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",


### PR DESCRIPTION
It was too limiting on ElasticSearch official version and wouldn't accept current version which is 5.1